### PR TITLE
Removed smtplib

### DIFF
--- a/ext/requirements.txt
+++ b/ext/requirements.txt
@@ -2,4 +2,3 @@ argparse
 requests
 datetime
 ConfigParser
-smtplib


### PR DESCRIPTION
The **requirement `smtplib` is not required** as it comes by default with Python.
Even doing a `pip install smtplib` will end up in the following error:
```
Collecting smtplib
  Could not find a version that satisfies the requirement smtplib (from versions: )
No matching distribution found for smtplib
```